### PR TITLE
✨ Add tag and folder_tagging model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Style/HashSyntax:
 
 Metrics/MethodLength:
   Exclude:
+    - "app/models/folder.rb"
     - "app/controllers/api/v1/links_controller.rb"
     - "db/migrate/20220912024024_devise_token_auth_create_users.rb"
 

--- a/app/controllers/api/v1/folders_controller.rb
+++ b/app/controllers/api/v1/folders_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::FoldersController < ApplicationController
   before_action :authenticate_api_v1_user!, only: %i[create update destroy my_folders favorite_folders]
   before_action :correct_user, only: %i[update destroy]
+  before_action :correct_tag, only: %i[by_tag]
 
   def show
     folder = Folder.find(params[:id])
@@ -9,7 +10,8 @@ class Api::V1::FoldersController < ApplicationController
 
     render status: :ok, json: {
       folder: folder.as_json({ include: [{ user: { only: %i[id name email] } },
-                                         { folder_favorites: { only: %i[id user_id] } }] }),
+                                         { folder_favorites: { only: %i[id user_id] } },
+                                         { tags: { only: %i[id name] } }] }),
       links:,
       is_owner:
     }
@@ -19,6 +21,7 @@ class Api::V1::FoldersController < ApplicationController
     folder = current_api_v1_user.folders.build(folder_params)
 
     if folder.save
+      folder.save_tags(folder_tagging_params[:tags])
       render status: :created, json: folder.as_json(expect: %i[user_id])
     else
       render status: :internal_server_error, json: folder.errors
@@ -27,7 +30,8 @@ class Api::V1::FoldersController < ApplicationController
 
   def update
     if @folder.update(folder_params)
-      render status: :no_content
+      @folder.save_tags(folder_tagging_params[:tags])
+      render status: :ok, json: @folder.as_json(include: :tags)
     else
       render status: :internal_server_error, json: @folder.errors
     end
@@ -51,15 +55,33 @@ class Api::V1::FoldersController < ApplicationController
     render status: :ok, json: folders.as_json(include: :links)
   end
 
+  def by_tag
+    pagy, folders = pagy(@tag.folders.order_by(params[:sort]))
+    pagy_headers_merge(pagy)
+    render status: :ok, json: {
+      folders: folders.as_json(include: :links),
+      tag: @tag,
+      pagy:
+    }
+  end
+
   private
 
   def folder_params
     params.require(:folder).permit(:name, :description, :color, :icon)
   end
 
+  def folder_tagging_params
+    params.require(:folder).permit(tags: [])
+  end
+
   def correct_user
     @folder = Folder.find(params[:id])
 
     render status: :forbidden, json: { message: "不正なリクエストです" } if current_api_v1_user.id != @folder.user_id
+  end
+
+  def correct_tag
+    @tag = Tag.find(params[:id])
   end
 end

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -5,6 +5,8 @@ class Folder < ApplicationRecord
   belongs_to :user
   has_many :links, dependent: :destroy
   has_many :folder_favorites, dependent: :destroy
+  has_many :folder_taggings, dependent: :destroy
+  has_many :tags, through: :folder_taggings
 
   validate :folders_count_must_be_within_limit
   validates :name, presence: true, length: { maximum: 30 }

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -35,4 +35,20 @@ class Folder < ApplicationRecord
       name_asc
     end
   end
+
+  def save_tags(sent_tags)
+    current_tags = []
+    current_tags = tags.pluck(:name) unless tags.nil?
+    old_tags = current_tags - sent_tags
+    new_tags = sent_tags - current_tags
+
+    old_tags.each do |old|
+      tags.delete Tag.find_by(name: old)
+    end
+
+    new_tags.each do |new|
+      new_folder_tag = Tag.find_or_create_by(name: new)
+      tags << new_folder_tag
+    end
+  end
 end

--- a/app/models/folder_tagging.rb
+++ b/app/models/folder_tagging.rb
@@ -1,0 +1,6 @@
+class FolderTagging < ApplicationRecord
+  belongs_to :folder
+  belongs_to :tag
+
+  validates :folder_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :folder_taggings, dependent: :destroy
+  has_many :folders, through: :folder_taggings
+
+  validates :name, uniqueness: true, presence: true, length: { maximum: 20 }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,11 @@ Rails.application.routes.draw do
         get "auth/show_current_user", to: "auth/sessions#show_current_user"
       end
 
-      resources :folders, only: %i[show create update destroy]
+      resources :folders, only: %i[show create update destroy] do
+        member do
+          get "by_tag"
+        end
+      end
       get "my_folders", to: "folders#my_folders"
       get "favorite_folders", to: "folders#favorite_folders"
       resources :folder_favorites, only: %i[create destroy]

--- a/db/migrate/20230108131207_create_tags.rb
+++ b/db/migrate/20230108131207_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230108132314_create_folder_taggings.rb
+++ b/db/migrate/20230108132314_create_folder_taggings.rb
@@ -1,0 +1,10 @@
+class CreateFolderTaggings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :folder_taggings do |t|
+      t.references :folder, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230108134536_add_index_folder_id_and_tag_id_to_folder_taggings.rb
+++ b/db/migrate/20230108134536_add_index_folder_id_and_tag_id_to_folder_taggings.rb
@@ -1,0 +1,5 @@
+class AddIndexFolderIdAndTagIdToFolderTaggings < ActiveRecord::Migration[7.0]
+  def change
+    add_index :folder_taggings, %i[folder_id tag_id], unique: true
+  end
+end

--- a/db/migrate/20230108145132_add_unique_index_name_to_tags.rb
+++ b/db/migrate/20230108145132_add_unique_index_name_to_tags.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexNameToTags < ActiveRecord::Migration[7.0]
+  def change
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_08_074747) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_08_145132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_08_074747) do
     t.index ["folder_id"], name: "index_folder_favorites_on_folder_id"
     t.index ["user_id", "folder_id"], name: "index_folder_favorites_on_user_id_and_folder_id", unique: true
     t.index ["user_id"], name: "index_folder_favorites_on_user_id"
+  end
+
+  create_table "folder_taggings", force: :cascade do |t|
+    t.bigint "folder_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["folder_id", "tag_id"], name: "index_folder_taggings_on_folder_id_and_tag_id", unique: true
+    t.index ["folder_id"], name: "index_folder_taggings_on_folder_id"
+    t.index ["tag_id"], name: "index_folder_taggings_on_tag_id"
   end
 
   create_table "folders", force: :cascade do |t|
@@ -45,6 +55,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_08_074747) do
     t.text "image_url"
     t.index ["folder_id"], name: "index_links_on_folder_id"
     t.index ["user_id"], name: "index_links_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,6 +91,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_08_074747) do
 
   add_foreign_key "folder_favorites", "folders"
   add_foreign_key "folder_favorites", "users"
+  add_foreign_key "folder_taggings", "folders"
+  add_foreign_key "folder_taggings", "tags"
   add_foreign_key "folders", "users"
   add_foreign_key "links", "folders"
   add_foreign_key "links", "users"

--- a/spec/factories/folder_taggings.rb
+++ b/spec/factories/folder_taggings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :folder_tagging do
+    association :folder
+    association :tag
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { "ライフハック" }
+  end
+end

--- a/spec/models/folder_favorite_spec.rb
+++ b/spec/models/folder_favorite_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 RSpec.describe FolderFavorite, type: :model do
   describe 'Association' do
-    it "User と N:1 の関係である" do
+    it "User と 1:N の関係である" do
       expect(described_class.reflect_on_association(:user).macro).to eq :belongs_to
     end
 
-    it "Folder と N:1 の関係である" do
+    it "Folder と 1:N の関係である" do
       expect(described_class.reflect_on_association(:folder).macro).to eq :belongs_to
     end
   end

--- a/spec/models/folder_tagging_spec.rb
+++ b/spec/models/folder_tagging_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe FolderTagging, type: :model do
+  describe 'Association' do
+    it "Folder と 1:N の関係である" do
+      expect(described_class.reflect_on_association(:folder).macro).to eq :belongs_to
+    end
+
+    it "Tag と 1:N の関係である" do
+      expect(described_class.reflect_on_association(:tag).macro).to eq :belongs_to
+    end
+  end
+
+  describe 'Validation' do
+    let!(:folder_tagging) { create(:folder_tagging) }
+    let(:new_folder_tagging) do
+      build(:folder_tagging, folder_id: folder_tagging.folder_id, tag_id: folder_tagging.tag_id)
+    end
+
+    it '全てのパラメータが正しい場合、有効である' do
+      expect(folder_tagging).to be_valid
+    end
+
+    it 'folder_id が nil の場合、無効である' do
+      folder_tagging.folder_id = nil
+      expect(folder_tagging).to be_invalid
+    end
+
+    it 'tag_id が nil の場合、無効である' do
+      folder_tagging.tag_id = nil
+      expect(folder_tagging).to be_invalid
+    end
+
+    context 'folder_id と tag_id の組み合わせが重複している場合' do
+      it '無効である' do
+        expect(new_folder_tagging).to be_invalid
+      end
+
+      it 'DB への保存時にエラーが発生する' do
+        expect do
+          new_folder_tagging.save(validate: false)
+        end.to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  describe 'Validation' do
+    it '全てのパラメータが正しい場合、有効である' do
+      tag = build(:tag)
+      expect(tag).to be_valid
+    end
+
+    it 'name が nil の場合、無効である' do
+      tag = build(:tag, name: nil)
+      expect(tag).to be_invalid
+    end
+
+    it 'name が空白の場合、無効である' do
+      tag = build(:tag, name: " ")
+      expect(tag).to be_invalid
+    end
+
+    it 'name が空文字の場合、無効である' do
+      tag = build(:tag, name: "")
+      expect(tag).to be_invalid
+    end
+
+    it 'name が21文字以上の場合、無効である' do
+      tag = build(:tag, name: ("a" * 21).to_s)
+      expect(tag).to be_invalid
+    end
+
+    it 'name が20文字以下の場合、有効である' do
+      tag = build(:tag, name: ("a" * 20).to_s)
+      expect(tag).to be_valid
+    end
+
+    it '同じ name を持つ tag は無効である' do
+      tag_name = "ライフハック"
+      tag = create(:tag, name: tag_name)
+      new_tag = build(:tag, name: tag_name)
+      expect(new_tag).to be_invalid
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Tag, type: :model do
 
     it '同じ name を持つ tag は無効である' do
       tag_name = "ライフハック"
-      tag = create(:tag, name: tag_name)
+      create(:tag, name: tag_name)
       new_tag = build(:tag, name: tag_name)
       expect(new_tag).to be_invalid
     end

--- a/spec/requests/api/v1/folders_spec.rb
+++ b/spec/requests/api/v1/folders_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Api::V1::Folders", type: :request do
   let!(:auth_token) { user.create_new_auth_token }
   let!(:folder) { create(:folder, user_id: user.id) }
   let!(:others_folder) { create(:folder) }
-  let!(:params) { { name: "gathelinkのフォルダ", color: "#26a69a" } }
+  let!(:params) { { name: "gathelinkのフォルダ", color: "#26a69a", tags: %w[ライフハック Amazon] } }
 
   describe "GET /api/v1/folders/:id" do
     it "リクエストが成功すること" do
@@ -28,8 +28,9 @@ RSpec.describe "Api::V1::Folders", type: :request do
 
   describe "PATCH /api/v1/folders/:id" do
     it "リクエストが成功すること" do
-      patch api_v1_folder_path(folder.id), params: { folder: { name: "フォルダ名を変更" } }, headers: auth_token
-      expect(response).to have_http_status(:no_content)
+      patch api_v1_folder_path(folder.id), params: { folder: { name: "フォルダ名を変更", tags: %w[ライフハック Amazon] } },
+                                           headers: auth_token
+      expect(response).to have_http_status(:success)
     end
 
     it "ヘッダに認証情報が存在しない場合、リクエストが失敗すること" do


### PR DESCRIPTION
Closes #34 


- Tag model
- folder と tag の中間テーブルである folder_tagging model を追加
- tag の保存メソッドを追加
  - 受け取った tag の配列から、folder にタグを付与
  - タグ名が DB に存在しなければ新規作成
- tag に基づくフォルダ一覧をページ毎に返す API を作成
 